### PR TITLE
docs(issue-5): remove template comments from phase 1 files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,13 +2,8 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 
-# TODO (Team Task): Import the 'correct_code_with_ai' function from model_service.py\
 from model_service import correct_code_with_ai
-# from model_service import correct_code_with_ai
-
 app = FastAPI()
-
-# This middleware allows the frontend (running on a different address) to communicate with this backend.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"], # Allows all origins for simplicity.
@@ -17,18 +12,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# This Pydantic model defines the expected structure of the request body.
 class CodeSnippet(BaseModel):
     code: str
 
 @app.post("/api/correct")
 def correct_code_endpoint(snippet: CodeSnippet):
-    # This now calls the 'correct_code_with_ai' function from model_service.py
-    # In Phase 1, this function returns a mock response.
     corrected_code = correct_code_with_ai(snippet.code)
     return {"corrected_code": corrected_code}
 
-# To run this server:
-# 1. Navigate to the 'backend' directory in your terminal.
-# 2. Run the command: uvicorn main:app --reload
-# 3. Open your browser to http://127.0.0.1:8000/docs to see the API documentation.


### PR DESCRIPTION
Removed template comments from backend/main.py:
- Removed TODO comment about importing correct_code_with_ai
- Removed commented-out import statement
- Removed CORS middleware explanatory comment
- Removed Pydantic model structure explanation
- Removed "This now calls..." comment

Fixes #5
- Removed "In Phase 1..." mock response comment
- Removed "To run this server" instruction section (4 lines)

All template/placeholder comments have been cleaned up as phase 1 is now complete.